### PR TITLE
Add ability to generate nested belongs_to associations.

### DIFF
--- a/lib/seedie/associations/has_many.rb
+++ b/lib/seedie/associations/has_many.rb
@@ -12,7 +12,7 @@ module Seedie
           
           report(:associated_records, name: association_name, count: count, parent_name: model.to_s)
           count.times do |index|
-            field_values_set = FieldValuesSet.new(association_class, config, index).generate_field_values
+            field_values_set = FieldValuesSet.new(association_class, config, index).generate_field_values_with_associations
             record_creator = Model::Creator.new(record.send(association_name), reporters)
 
             record_creator.create!(field_values_set)

--- a/lib/seedie/model_seeder.rb
+++ b/lib/seedie/model_seeder.rb
@@ -12,7 +12,6 @@ module Seedie
       @config = config
       @record_creator = Model::Creator.new(model, reporters)
       @reporters = reporters
-
       add_observers(@reporters)
     end
 
@@ -40,21 +39,8 @@ module Seedie
     end
 
     def generate_record(model_config, index)
-      associated_field_set = generate_belongs_to_associations(model, model_config)
-
-      field_values_set = FieldValuesSet.new(model, model_config, index).generate_field_values
-      field_values_set.merge!(associated_field_set)
+      field_values_set = FieldValuesSet.new(model, model_config, index).generate_field_values_with_associations
       @record_creator.create!(field_values_set)
-    end
-
-    def generate_belongs_to_associations(model, model_config)
-      associations_config = model_config["associations"]
-      return {} unless associations_config.present?
-
-      belongs_to_associations = Associations::BelongsTo.new(model, associations_config, reporters)
-      belongs_to_associations.generate_associations
-      
-      return belongs_to_associations.associated_field_set
     end
   end
 end

--- a/spec/dummy/config/seedie.yml
+++ b/spec/dummy/config/seedie.yml
@@ -17,8 +17,7 @@ models:
     disabled_fields: []
   comment:
     attributes:
-      title: "title {{index}}"
-      associations:
-        belongs_to:
-          post: random
-          user: new
+      content: "title {{index}}"
+    associations:
+      belongs_to:
+        post: random

--- a/spec/fixtures/join_table_config.yml
+++ b/spec/fixtures/join_table_config.yml
@@ -1,0 +1,31 @@
+
+default_count: 5
+models:
+  simple_model:
+    attributes: 
+      name: "name {{index}}"
+      content: "content {{index}}"
+      category:
+        values: [tech, news, sports, politics, entertainment]
+        options: { pick_strategy: sequential }
+      score:
+        values: 
+          start: 0
+          end: 100
+        options: { pick_strategy: sequential }
+    disabled_fields: [status]
+  user:
+    attributes:
+      name: "name {{index}}"
+      email: "{{Faker::Internet.email}}"
+      address: "{{Faker::Address.street_address}}"
+    disabled_fields: [nickname password password_digest]
+    associations:
+      has_many: 
+        reviews: 
+          disabled_fields: [review_type]
+          associations:
+            belongs_to:
+              reviewable:
+                polymorphic: simple_model
+                strategy: random

--- a/spec/integration/join_table_seed_spec.rb
+++ b/spec/integration/join_table_seed_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "JoinTablesSeed" do
+  let(:config_path) { "spec/fixtures/join_table_config.yml" }
+
+  describe "seeding the User Model" do
+    before do
+      Seedie::Seeder.new(config_path).seed_models
+    end
+
+    it "seeds the User model based on the given config" do
+      expect(User.count).to eq 5
+      expect(User.first.name).to eq "name 0"
+    end
+
+    it "Creates Has many association for Review" do
+      expect(Review.first.reviewable_type).to eq("SimpleModel")
+      expect(Review.first.user_id).to be_in(User.ids)
+    end
+  end
+end

--- a/spec/seedie/field_values_set_spec.rb
+++ b/spec/seedie/field_values_set_spec.rb
@@ -39,4 +39,16 @@ describe Seedie::FieldValuesSet do
       expect(subject.generate_field_values).to include({ "virtual_field" => "Virtual Field Value" })
     end
   end
+
+  describe "#generate_field_values_with_associations" do
+    before do
+      Post.create!(title: "Post Title")
+    end
+
+    it "generates values for belongs_to associations" do
+      model_config["associations"] = { "belongs_to" => { "post" => "random" } }
+
+      expect(subject.generate_field_values_with_associations).to include({ "post_id" => 1 })
+    end
+  end
 end


### PR DESCRIPTION
If you're seedie.yml looked like this:

```yaml
parent_model:
  attributes:
    some_attribute: 'hello'
child_model:
  associations:
    belongs_to:
      parent_model: 'random'
```

This would work. But if it's the other way round:

```yaml
parent_model:
  attributes:
    some_attribute: 'hello'
  associations:
    has_many:
      child_model: 2
```

This would only work if Child model is not a Join Table or if there isn't another required `belongs_to` association.

This PR fixes this by adding ability to write nested associations for belongs to

Now you can write:

```yaml
parent_model:
  attributes:
    some_attribute: 'hello'
  associations:
    has_many:
      child_model:
        attributes:
          title: 'some title'
        associations:
          belongs_to:
            another_parent_model: 'random'
```

